### PR TITLE
Resolve incorrect readlink method name

### DIFF
--- a/Sources/SwordRPC/Register.swift
+++ b/Sources/SwordRPC/Register.swift
@@ -69,11 +69,7 @@ extension SwordRPC {
         free(exec)
       }
       
-      #if !os(Linux)
-      let n = readLink("/proc/self/exe", exec, Int(PATH_MAX))
-      #else
       let n = readlink("/proc/self/exe", exec, Int(PATH_MAX))
-      #endif
       guard n >= 0 else {
         print("[SwordRPC] Error getting game's execution path")
         return

--- a/Sources/SwordRPC/Register.swift
+++ b/Sources/SwordRPC/Register.swift
@@ -69,7 +69,11 @@ extension SwordRPC {
         free(exec)
       }
       
+      #if !os(Linux)
       let n = readLink("/proc/self/exe", exec, Int(PATH_MAX))
+      #else
+      let n = readlink("/proc/self/exe", exec, Int(PATH_MAX))
+      #endif
       guard n >= 0 else {
         print("[SwordRPC] Error getting game's execution path")
         return


### PR DESCRIPTION
~~In Register.swift line 72, the `readLink` method is used. I think this is part of CoreServices where it is defined with a capital letter L. However, there is a conditional import to use Glibc instead if on Linux where `readlink` is defined with a lowercase l.
This wraps line 72 in an if-else to use the Glibc version of the method when needed.~~

This PR resolves a typo in Register.swift which was causing building on Linux to fail.